### PR TITLE
Fix Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # SwiftySCAD
-##A Swift framework to generate 3D models.  
+## A Swift framework to generate 3D models.  
 Exports to OpenSCAD and .stl
 <br><br><br>
 
-##Write awesome functional 3D modeling code in Swift  
+## Write awesome functional 3D modeling code in Swift  
 
 <img src="https://github.com/bearMountain/SwiftySCAD/blob/dev/GitResources/SwiftCode.png" width="700">  
 <br><br><br>
 
-##Beautifully formatted OpenSCAD is automatically output  
+## Beautifully formatted OpenSCAD is automatically output  
 
 <img src="https://github.com/bearMountain/SwiftySCAD/blob/dev/GitResources/SCADCode.png" width="700">
 <br><br><br>
 
-##Enjoy the Three Dimensional fruits of your labor in the OpenSCAD IDE  
+## Enjoy the Three Dimensional fruits of your labor in the OpenSCAD IDE  
 
 <img src="https://github.com/bearMountain/SwiftySCAD/blob/dev/GitResources/RenderedTire.png" width="400">
 <br><br><br>


### PR DESCRIPTION
GitHub's preview of the changes don't look that useful, but I changed from:

```md
##The old header format
```

To:

```md
## The new header format
```

## Demo:

##The old header format

## The new header format